### PR TITLE
fix: removed translators on community footer

### DIFF
--- a/src/components/Layout/Footer.tsx
+++ b/src/components/Layout/Footer.tsx
@@ -319,7 +319,6 @@ export function Footer() {
           <FooterLink href="/community/docs-contributors">
             Docs Contributors
           </FooterLink>
-          <FooterLink href="/community/translators">번역한 사람들</FooterLink>
           <FooterLink href="/community/acknowledgements">
             Acknowledgements
           </FooterLink>

--- a/src/sidebarCommunity.json
+++ b/src/sidebarCommunity.json
@@ -32,11 +32,6 @@
           "path": "/community/docs-contributors"
         },
         {
-          "title": "Translation Contributors",
-          "translatedTitle": "번역한 사람들",
-          "path": "/community/translators"
-        },
-        {
           "title": "Acknowledgements",
           "path": "/community/acknowledgements"
         },


### PR DESCRIPTION
<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/react.dev/blob/main/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
## 문제 상황
하단 Community의 번역한 사람들
Community 에서 Sidebar 메뉴에서 번역한 사람들 클릭시 404 Page Not Found Error

## 조치
[3798a2c: translators 메뉴 top으로 이동](https://github.com/ft-jasong/react.dev.ko/commit/3798a2c268ba025ac2a0189bf6e75dc0cce52956)를 참고하여 Community에서 상단으로 이동한것으로 확인하고, Community에서는 삭제헸습니다.

임의로 취한 조치이니 편하신대로 하시면 좋을 듯합니다.
리액트 공부 시작하는데 도움이 많이 됩니다. 감사합니다🙇‍♂️
